### PR TITLE
Enable config flow from UI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,16 @@
 [flake8]
 application-import-names = homeassistant,eventsensor
-import-order-style = smarkets
+import-order-style = cryptography
 inline-quotes = double
-max-complexity = 15
+max-complexity = 10
 multiline-quotes = double
+max-line-length = 88
+# W503: Line break occurred before a binary operator
+# E203: Whitespace before ':'
+# D202 No blank lines allowed after function docstring
+# W504 line break after binary operator
+ignore =
+    W503,
+    E203,
+    D202,
+    W504

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
     hooks:
       - id: flake8
         name: Lint code (flake8)
-        args: ['--ignore=W503,PIE782']
         additional_dependencies:
           - flake8==3.7.9
           - flake8-broken-line==0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased v2.0.0](https://github.com/azogue/eventsensor/tree/feature/config-flow)
+
+[Full Changelog](https://github.com/azogue/eventsensor/compare/v1.0.0...feature/config-flow)
+
+**Implemented enhancements:**
+
+- Add config entry support + full UI support with config flows.
+
 ## [v1.0.0](https://github.com/azogue/eventsensor/tree/v1.0.0) (2020-04-17)
 
 **Initial version**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Validate with hassfest](https://github.com/azogue/eventsensor/workflows/Validate%20with%20hassfest/badge.svg?branch=master)
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 <br><a href="https://www.buymeacoffee.com/azogue" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-black.png" width="150px" height="35px" alt="Buy Me A Coffee" style="height: 35px !important;width: 150px !important;" ></a>
@@ -117,8 +117,3 @@ key | optional | type | default | description
 `event_data` | True | dict | Empty (all events) | A dict with key-value pairs required in the event data, to filter specific events.
 `state` | False | string | | Event data key used for the sensor state.
 `state_map` | True | map | | State conversion from raw data in event to desired state.
-
-## TODO
-
-- [ ] Inclusion as [HACS](https://hacs.xyz/) **default** integration (manual addition to HACS is already possible)
-- [ ] Config flow to define these sensors via UI, so it could be used easily for debug purposes without any HA restart.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,47 @@ but could be useful in other scenarios where some specific event needs to be tra
 
 ## Installation
 
+### HACS _(preferred method)_
+
+**Add the integration in [HACS](https://hacs.xyz/)** and start using it without any HA restart :)
+
+### Manual install
+
 Place the `custom_components` folder in your configuration directory
 (or add its contents to an existing `custom_components` folder).
 
 ## Configuration
+
+2 ways of configuration are implemented: **via UI** from the Integrations menu,
+and, as _legacy mode_, via manual YAML config as a _sensor platform_.
+
+Sensors configured manually in YAML will log a deprecation warning, advising to remove the yaml,
+after importing them to config entries handled via Integrations UI.
+
+### Wizard for UI config _(preferred method)_
+
+Go to the Integrations menu, look for `EventSensor`, and start the wizard.
+
+1. Set a name for the sensor and a HA integration as source for the events to listen for.
+  For _Friends of Hue_ remotes, select "Hue" or "deCONZ" to preconfigure the event sensor. Select "Any other" otherwise.
+2. If Hue or deCONZ are selected, use step 2 to set a unique identifier to filter events for an specific device. Leave that field empty to create a sensor showing button presses for all devices. 2 options are shown, filter by `id` or by `unique_id`:
+   * `id` is the _slugified_ version of the given name for the device, so for a Hue dimmer battery sensor named `sensor.hue_dimmer_kitchen_battery_level`, the `id` would be "hue_dimmer_kitchen".
+   * `unique_id` is serial number of the device, (example: "00:17:88:01:10:3e:3a:dc-02-fc00").
+
+   Last field is to select one of the pre-configured state mappings for Hue remotes. Set it as "Custom state mapping" to define your own.
+3. Use the last step to review or customize the optional state mapping and confirm the sensor creation.
+
+   Follow the instructions to introduce the mapping as a text in that field, as pairs between commas, with the syntax: `code: state1, code2: state2, code3: state3`.
+
+#### Generic sensor definition
+
+* When "Any other" is selected in step 1, the next step shows a full manual configuration for the sensor.
+
+* For any loaded event sensor, the Options menu is available to show or **edit** all sensor parameters,
+  so any change in the sensor definition can be made without removing + adding a new one, and of course without any HA restart.
+
+
+### Manual yaml config
 
 Once installed add to your yaml configuration the desired sensors like in the next examples.
 
@@ -116,4 +153,4 @@ key | optional | type | default | description
 `event` | False | string | | Name of the event to track.
 `event_data` | True | dict | Empty (all events) | A dict with key-value pairs required in the event data, to filter specific events.
 `state` | False | string | | Event data key used for the sensor state.
-`state_map` | True | map | | State conversion from raw data in event to desired state.
+`state_map` | True | dict | | State conversion from raw data in event to desired state.

--- a/custom_components/eventsensor/.translations/en.json
+++ b/custom_components/eventsensor/.translations/en.json
@@ -1,0 +1,59 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "A sensor for that specific event data is already configured",
+            "forbidden_event": "This sensor for events can't listen to `state_changed`"
+        },
+        "step": {
+            "generic": {
+                "data": {
+                    "event": "Event name to listen to",
+                    "event_data": "Filter with `key: value` pairs inside the event data",
+                    "state": "Event field to use as sensor `state`",
+                    "state_map": "Desired mapping for the sensor states"
+                },
+                "description": "Define a custom event listener by setting:\n\n* Event name\n* Event field `key` to use as the sensor state\n* `key: value` pairs inside the event data to filter specific events\n* Custom mapping for sensor states\n\nTo define a custom mapping, introduce it as pairs between commas, like:\n**`code: state1, code2: state2, code3: state3`**",
+                "title": "EventSensor - generic definition"
+            },
+            "preset": {
+                "data": {
+                    "identifier": "Unique identifier for device firing events (leave empty for all devices)",
+                    "preset_config": "Select one of the pre-configured state mappings, or define a generic one",
+                    "type_identifier": "Select the identifier field used to filter events for a specific remote"
+                },
+                "description": "* Add a unique identifier to filter events related to a specific remote.\n* Select a preconfigured mapping for custom states, or define a new one",
+                "title": "EventSensor - listener for FoH remote"
+            },
+            "state_mapping": {
+                "data": {
+                    "state_map": "Desired mapping for the sensor states as `raw_data: pretty_state,` pairs."
+                },
+                "description": "* Review or modify the state mapping for this sensor, or leave it empty for no special state mapping.\n\nTo define a custom mapping, introduce it as pairs between commas, like:\n**`code: state1, code2: state2, code3: state3`**",
+                "title": "EventSensor - custom state mapping"
+            },
+            "user": {
+                "data": {
+                    "integration_source": "Integration firing events to listen for",
+                    "name": "Name for the new sensor tracking events"
+                },
+                "description": "Create a **sensor entity** to show state and attributes for the last fired event of some kind.\n\n* Set a name for the new sensor\n* Select a specific Integration source for the events to listen for, or select 'Any other' to define a generic event listener.",
+                "title": "EventSensor - new"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "event": "Event name to listen to",
+                    "event_data": "Optional event filter with `key: value` pairs inside the event data",
+                    "name": "Name of the sensor",
+                    "state": "Event field to use as sensor `state`",
+                    "state_map": "Optional custom state mapping"
+                },
+                "description": "Edit the sensor event listener by changing:\n\n* Sensor name\n* Event name\n* Event field `key` to use as the sensor state\n* Optional `key: value` pairs inside the event data to filter specific events\n* Optional custom mapping for sensor states\n\nTo define a custom mapping, introduce it as pairs between commas, like:\n**`code: state1, code2: state2, code3: state3`**",
+                "title": "EventSensor - Edit sensor"
+            }
+        }
+    }
+}

--- a/custom_components/eventsensor/__init__.py
+++ b/custom_components/eventsensor/__init__.py
@@ -1,1 +1,35 @@
 """Event sensor integration."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+
+from .common import DOMAIN_DATA, PLATFORM
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
+    """Set up the EventSensor component."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+    """Set up the component from a config entry."""
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, PLATFORM)
+    )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
+    """Unload a config entry."""
+    # forward unload
+    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, PLATFORM)
+
+    if unload_ok:
+        # remove update listener
+        hass.data[DOMAIN_DATA].pop(entry.entry_id)()
+
+        # remove entity from registry
+        entity_registry = await er.async_get_registry(hass)
+        entity_registry.async_clear_config_entry(entry.entry_id)
+
+    return unload_ok

--- a/custom_components/eventsensor/common.py
+++ b/custom_components/eventsensor/common.py
@@ -1,0 +1,65 @@
+"""Constants for eventsensor."""
+from homeassistant.const import CONF_EVENT, CONF_EVENT_DATA, CONF_STATE
+from homeassistant.util import slugify
+
+# Base component constants
+DOMAIN = "eventsensor"
+PLATFORM = "sensor"
+DOMAIN_DATA = f"{DOMAIN}_data"
+
+CONF_STATE_MAP = "state_map"
+
+PRESET_FOH = "FoH Switch"
+PRESET_FOH_MAPPING = {
+    16: "left_upper_press",
+    20: "left_upper_release",
+    17: "left_lower_press",
+    21: "left_lower_release",
+    18: "right_lower_press",
+    22: "right_lower_release",
+    19: "right_upper_press",
+    23: "right_upper_release",
+    100: "double_upper_press",
+    101: "double_upper_release",
+    98: "double_lower_press",
+    99: "double_lower_release",
+}
+PRESET_HUE_DIMMER = "Hue Dimmer Switch"
+PRESET_HUE_DIMMER_MAPPING = {
+    1000: "1_click",
+    2000: "2_click",
+    3000: "3_click",
+    4000: "4_click",
+    1001: "1_hold",
+    2001: "2_hold",
+    3001: "3_hold",
+    4001: "4_hold",
+    1002: "1_click_up",
+    2002: "2_click_up",
+    3002: "3_click_up",
+    4002: "4_click_up",
+    1003: "1_hold_up",
+    2003: "2_hold_up",
+    3003: "3_hold_up",
+    4003: "4_hold_up",
+}
+PRESET_HUE_TAP = "Hue Tap Switch"
+PRESET_HUE_TAP_MAPPING = {
+    34: "1_click",
+    16: "2_click",
+    17: "3_click",
+    18: "4_click",
+}
+
+
+def make_unique_id(sensor_data: dict) -> str:
+    """
+    Generate an unique id from the listened event + data filters.
+
+    Used for both the generated sensor entity and the config entry.
+    """
+    event: str = sensor_data.get(CONF_EVENT)
+    state: str = sensor_data.get(CONF_STATE)
+    filter_event: dict = dict(sensor_data.get(CONF_EVENT_DATA, {}))
+    state_map: dict = dict(sensor_data.get(CONF_STATE_MAP, {}))
+    return "_".join([event, slugify(str(filter_event)), state, slugify(str(state_map))])

--- a/custom_components/eventsensor/config_flow.py
+++ b/custom_components/eventsensor/config_flow.py
@@ -1,0 +1,272 @@
+"""Adds config flow for eventsensor."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_EVENT, CONF_EVENT_DATA, CONF_NAME, CONF_STATE
+from homeassistant.core import callback
+from homeassistant.helpers.event import EVENT_STATE_CHANGED
+
+from .common import (
+    CONF_STATE_MAP,
+    DOMAIN,
+    PRESET_FOH,
+    PRESET_FOH_MAPPING,
+    PRESET_HUE_DIMMER,
+    PRESET_HUE_DIMMER_MAPPING,
+    PRESET_HUE_TAP,
+    PRESET_HUE_TAP_MAPPING,
+    make_unique_id,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_PRESET_CONFIG = "preset_config"
+CONF_INTEGRATION = "integration_source"
+CONF_IDENTIFIER = "identifier"
+CONF_TYPE_IDENTIFIER = "type_identifier"
+
+_EVENT_SOURCE_HUE = "Hue"
+_EVENT_SOURCE_DECONZ = "deCONZ"
+_EVENT_SOURCE_GENERIC = "Any other"
+_IDENTIFIER_ID = "id"
+_IDENTIFIER_UNIQUE_ID = "uniqueid"
+_PRESET_GENERIC = "generic event source"
+
+STEP_1_INITIAL = vol.Schema(
+    {
+        vol.Required(CONF_NAME): str,
+        vol.Required(CONF_INTEGRATION, default=_EVENT_SOURCE_HUE): vol.In(
+            [_EVENT_SOURCE_HUE, _EVENT_SOURCE_DECONZ, _EVENT_SOURCE_GENERIC]
+        ),
+    },
+)
+STEP_2_PRECONFIGURED = vol.Schema(
+    {
+        vol.Required(CONF_TYPE_IDENTIFIER, default=_IDENTIFIER_ID): vol.In(
+            [_IDENTIFIER_ID, _IDENTIFIER_UNIQUE_ID]
+        ),
+        vol.Optional(CONF_IDENTIFIER, default=""): str,
+        vol.Required(CONF_PRESET_CONFIG, default=PRESET_HUE_DIMMER): vol.In(
+            [PRESET_HUE_DIMMER, PRESET_HUE_TAP, PRESET_FOH, _PRESET_GENERIC]
+        ),
+    },
+)
+STEP_2_GENERIC_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_EVENT): str,
+        vol.Required(CONF_STATE): str,
+        vol.Optional(CONF_EVENT_DATA, default=""): str,
+        vol.Optional(CONF_STATE_MAP, default=""): str,
+    },
+)
+
+
+def _from_str_to_dict(raw_data: str) -> dict:
+    """Assume format `key1: value1, key2: value2, ...`."""
+    raw_pairs = raw_data.split(",")
+
+    def _parse_key(raw_key: str):
+        return raw_key.lstrip(" ").rstrip(" ").rstrip(":")
+
+    data = {}
+    for pair in raw_pairs:
+        if ":" not in pair:
+            break
+        key, value = pair.split(":", maxsplit=1)
+        data[_parse_key(key)] = _parse_key(value)
+
+    return data
+
+
+def _from_dict_to_str(data: dict) -> str:
+    """Assume format `key1: value1, key2: value2, ...`."""
+    return ", ".join([f"{key}: {value}" for key, value in data.items()])
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class EventSensorFlowHandler(config_entries.ConfigFlow):
+    """Config flow for eventsensor."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    def __init__(self):
+        """Initialize."""
+        self._data_steps_config = {}
+
+    async def _create_entry(self):
+        event = self._data_steps_config.get(CONF_EVENT)
+        if event == EVENT_STATE_CHANGED:
+            return self.async_abort(reason="forbidden_event")
+
+        unique_id = make_unique_id(self._data_steps_config)
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        name = self._data_steps_config.get(CONF_NAME)
+        entry_data = {
+            CONF_NAME: name,
+            CONF_EVENT: self._data_steps_config.get(CONF_EVENT),
+            CONF_EVENT_DATA: self._data_steps_config.get(CONF_EVENT_DATA, {}),
+            CONF_STATE: self._data_steps_config.get(CONF_STATE),
+            CONF_STATE_MAP: self._data_steps_config.get(CONF_STATE_MAP, {}),
+        }
+
+        return self.async_create_entry(title=name, data=entry_data)
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            self._data_steps_config[CONF_NAME] = user_input.get(CONF_NAME)
+
+            event_source = user_input.get(CONF_INTEGRATION)
+            if event_source == _EVENT_SOURCE_HUE:
+                self._data_steps_config[CONF_EVENT] = "hue_event"
+                self._data_steps_config[CONF_STATE] = "event"
+
+            elif event_source == _EVENT_SOURCE_DECONZ:
+                self._data_steps_config[CONF_EVENT] = "deconz_event"
+                self._data_steps_config[CONF_STATE] = "event"
+
+            else:
+                return await self.async_step_generic()
+
+            return await self.async_step_preset()
+
+        return self.async_show_form(step_id="user", data_schema=STEP_1_INITIAL)
+
+    async def async_step_preset(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            type_id = user_input.get(CONF_TYPE_IDENTIFIER)
+            identifier = user_input.get(CONF_IDENTIFIER)
+            filter_map = {}
+            if identifier:
+                filter_map = {type_id: identifier}
+            self._data_steps_config[CONF_EVENT_DATA] = filter_map
+
+            preset_map = {}
+            preset_config = user_input.get(CONF_PRESET_CONFIG)
+            if preset_config == PRESET_HUE_DIMMER:
+                preset_map = PRESET_HUE_DIMMER_MAPPING
+            elif preset_config == PRESET_HUE_TAP:
+                preset_map = PRESET_HUE_TAP_MAPPING
+            elif preset_config == PRESET_FOH:
+                preset_map = PRESET_FOH_MAPPING
+            self._data_steps_config[CONF_STATE_MAP] = preset_map
+
+            return await self.async_step_state_mapping()
+
+        return self.async_show_form(step_id="preset", data_schema=STEP_2_PRECONFIGURED)
+
+    async def async_step_generic(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            self._data_steps_config[CONF_EVENT] = user_input.get(CONF_EVENT)
+            self._data_steps_config[CONF_STATE] = user_input.get(CONF_STATE)
+
+            filter_map = {}
+            raw_filter_map = user_input.get(CONF_EVENT_DATA)
+            if raw_filter_map:
+                filter_map = _from_str_to_dict(raw_filter_map)
+            self._data_steps_config[CONF_EVENT_DATA] = filter_map
+
+            state_map = {}
+            raw_state_map = user_input.get(CONF_STATE_MAP)
+            if raw_state_map:
+                state_map = _from_str_to_dict(raw_state_map)
+            self._data_steps_config[CONF_STATE_MAP] = state_map
+
+            return await self._create_entry()
+
+        return self.async_show_form(
+            step_id="generic", data_schema=STEP_2_GENERIC_SCHEMA
+        )
+
+    async def async_step_state_mapping(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            state_map = {}
+            raw_state_map = user_input.get(CONF_STATE_MAP)
+            if raw_state_map:
+                state_map = _from_str_to_dict(raw_state_map)
+            self._data_steps_config[CONF_STATE_MAP] = state_map
+
+            return await self._create_entry()
+
+        state_map_ui = _from_dict_to_str(
+            self._data_steps_config.get(CONF_STATE_MAP, {})
+        )
+        return self.async_show_form(
+            step_id="state_mapping",
+            data_schema=vol.Schema(
+                {vol.Optional(CONF_STATE_MAP, default=state_map_ui): str},
+            ),
+        )
+
+    async def async_step_import(self, import_info):
+        """Handle import from YAML config file."""
+        self._data_steps_config.update(import_info)
+        return await self._create_entry()
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+        """Get the options flow for this handler to make a tariff change."""
+        return EventSensorOptionsFlowHandler(config_entry)
+
+
+class EventSensorOptionsFlowHandler(config_entries.OptionsFlow):
+    """
+    Handle the Options flow for `eventsensor` to edit the configuration.
+
+    **entry.options is used as a container to make changes over entry.data**
+    """
+
+    def __init__(self, config_entry: config_entries.ConfigEntry):
+        """Initialize the options flow handler with the config entry to modify."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            # Inverse conversion for mappings shown as strings
+            for c in (CONF_EVENT_DATA, CONF_STATE_MAP):
+                user_input[c] = _from_str_to_dict(user_input[c])
+
+            new_unique_id = make_unique_id(user_input)
+            if self.config_entry.unique_id != new_unique_id:
+                # check change of unique_id to prevent collisions
+                for entry in filter(
+                    lambda x: x.entry_id != self.config_entry.entry_id,
+                    self.hass.config_entries.async_entries(DOMAIN),
+                ):
+                    if entry.unique_id == new_unique_id:
+                        _LOGGER.error(
+                            "The `unique_id` is already used by another sensor"
+                        )
+                        return self.async_abort(reason="already_configured")
+
+            return self.async_create_entry(title="", data=user_input)
+
+        # Fill options with entry data
+        container = self.config_entry.data
+        name = container.get(CONF_NAME)
+        event = container.get(CONF_EVENT)
+        state = container.get(CONF_STATE)
+        filter_ev_str = _from_dict_to_str(container.get(CONF_EVENT_DATA))
+        state_map_str = _from_dict_to_str(container.get(CONF_STATE_MAP))
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NAME, default=name): str,
+                    vol.Required(CONF_EVENT, default=event): str,
+                    vol.Required(CONF_STATE, default=state): str,
+                    vol.Optional(CONF_EVENT_DATA, default=filter_ev_str): str,
+                    vol.Optional(CONF_STATE_MAP, default=state_map_str): str,
+                },
+            ),
+        )

--- a/custom_components/eventsensor/config_flow.py
+++ b/custom_components/eventsensor/config_flow.py
@@ -32,7 +32,7 @@ _EVENT_SOURCE_DECONZ = "deCONZ"
 _EVENT_SOURCE_GENERIC = "Any other"
 _IDENTIFIER_ID = "id"
 _IDENTIFIER_UNIQUE_ID = "uniqueid"
-_PRESET_GENERIC = "generic event source"
+_PRESET_GENERIC = "Custom state mapping"
 
 STEP_1_INITIAL = vol.Schema(
     {

--- a/custom_components/eventsensor/manifest.json
+++ b/custom_components/eventsensor/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "eventsensor",
-    "name": "Event sensor custom integration",
+    "name": "EventSensor",
+    "config_flow": true,
     "documentation": "https://github.com/azogue/eventsensor",
     "requirements": [],
     "dependencies": [],

--- a/custom_components/eventsensor/strings.json
+++ b/custom_components/eventsensor/strings.json
@@ -1,0 +1,59 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "EventSensor - new",
+        "description": "Create a **sensor entity** to show state and attributes for the last fired event of some kind.\n\n* Set a name for the new sensor\n* Select a specific Integration source for the events to listen for, or select 'Any other' to define a generic event listener.",
+        "data": {
+          "name": "Name for the new sensor tracking events",
+          "integration_source": "Integration firing events to listen for"
+        }
+      },
+      "preset": {
+        "title": "EventSensor - listener for FoH remote",
+        "description": "* Add a unique identifier to filter events related to a specific remote.\n* Select a preconfigured mapping for custom states, or define a new one",
+        "data": {
+          "type_identifier": "Select the identifier field used to filter events for a specific remote",
+          "identifier": "Unique identifier for device firing events (leave empty for all devices)",
+          "preset_config": "Select one of the pre-configured state mappings, or define a generic one"
+        }
+      },
+      "state_mapping": {
+        "title": "EventSensor - custom state mapping",
+        "description": "* Review or modify the state mapping for this sensor, or leave it empty for no special state mapping.\n\nTo define a custom mapping, introduce it as pairs between commas, like:\n**`code: state1, code2: state2, code3: state3`**",
+        "data": {
+          "state_map": "Desired mapping for the sensor states as `raw_data: pretty_state,` pairs."
+        }
+      },
+      "generic": {
+        "title": "EventSensor - generic definition",
+        "description": "Define a custom event listener by setting:\n\n* Event name\n* Event field `key` to use as the sensor state\n* `key: value` pairs inside the event data to filter specific events\n* Custom mapping for sensor states\n\nTo define a custom mapping, introduce it as pairs between commas, like:\n**`code: state1, code2: state2, code3: state3`**",
+        "data": {
+          "event": "Event name to listen to",
+          "state": "Event field to use as sensor `state`",
+          "event_data": "Filter with `key: value` pairs inside the event data",
+          "state_map": "Desired mapping for the sensor states"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "A sensor for that specific event data is already configured",
+      "forbidden_event": "This sensor for events can't listen to `state_changed`"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "EventSensor - Edit sensor",
+        "description": "Edit the sensor event listener by changing:\n\n* Sensor name\n* Event name\n* Event field `key` to use as the sensor state\n* Optional `key: value` pairs inside the event data to filter specific events\n* Optional custom mapping for sensor states\n\nTo define a custom mapping, introduce it as pairs between commas, like:\n**`code: state1, code2: state2, code3: state3`**",
+        "data": {
+          "name": "Name of the sensor",
+          "event": "Event name to listen to",
+          "state": "Event field to use as sensor `state`",
+          "event_data": "Optional event filter with `key: value` pairs inside the event data",
+          "state_map": "Optional custom state mapping"
+        }
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eventsensor"
-version = "0.1.0"
+version = "2.0.0"
 description = "HomeAssistant custom sensor to track specific events"
 authors = ["Eugenio Panadero <eugenio.panadero@gmail.com>"]
 license = "MIT"
@@ -11,9 +11,7 @@ python = "^3.7"
 [tool.poetry.dev-dependencies]
 
 [tool.black]
-line_length = 79
-target_version = ["py37"]
-
+target_version = ["py37", "py38"]
 
 [build-system]
 requires = ["poetry>=1.0.0"]


### PR DESCRIPTION
### Changes

- Add `config_entry` support for `EventSensor`
- Add config flow + options flow
  - Enable yaml manual config import, logging a warning when importing a yaml config sensor via sensor platform
  - Enable **full config of event sensors in UI**, with a wizard for hue remotes:
    * Step 1 sets name and event source, to pre-configure hue remotes in Hue and deCONZ integrations.
    * Step 2 for hue remotes sets identifier & state mapping (with examples).
    * Step 3 checks the state mapping, enabling customization
    * For generic event sensors, step 2 edits all parameters
- Enable edition of configured sensors via `OptionsFlow`, where any sensor can be changed for any detail.
- Add some **preconfigured state mappings for hue remotes** (extracted from Hass-remotes CC)
- Add a default icon for these sensors (can be easily changed via UI)

