### PR TITLE
Implement a better filter for event_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ sensor:
       # ...
 ```
 
-#### Sensor Configuration
+## Sensor Configuration
 
 key | optional | type | default | description
 -- | -- | -- | -- | --
@@ -183,3 +183,42 @@ key | optional | type | default | description
 `event_data` | True | dict | Empty (all events) | A dict with key-value pairs required in the event data, to filter specific events.
 `state` | False | string | | Event data key used for the sensor state.
 `state_map` | True | dict | | State conversion from raw data in event to desired state.
+
+### Listening to events with nested data
+
+For both the `event_data` and the desired sensor `state`, the _dot.notation_ can be used to point to nested keys in the event data, so, for an event like:
+
+```json
+{
+    "event_type": "netatmo_event",
+    "data": {
+        "type": "movement",
+        "data": {
+            "user_id": "x",
+            "snapshot_id": "x",
+            "snapshot_key": "x",
+            "snapshot_url": "x",
+            "event_type": "movement",
+            "camera_id": "ma:ca:dr:es:sx:xx",
+            "device_id": "ma:ca:dr:es:sx:xx",
+            "home_id": "x",
+            "home_name": "x",
+            "event_id": "x",
+            "message": "Bewegung von Camera Treppenhaus erkannt",
+            "push_type": "NACamera-movement"
+        }
+    },
+    "origin": "LOCAL",
+    "time_fired": "2020-07-25T09:12:49.580668+00:00",
+    "context": {
+        "id": "x",
+        "parent_id": null,
+        "user_id": null
+    }
+}
+```
+
+To filter with the `type` and the `device_id` value, and create the state with the `push_type` data, the configuration in UI would be as follows:
+
+* Event field: `data.push_type`
+* Event filter: `type: movement, data.device_id: ma:ca:dr:es:sx:xx`

--- a/custom_components/eventsensor/common.py
+++ b/custom_components/eventsensor/common.py
@@ -185,3 +185,38 @@ def parse_dict_from_ui_string(str_use) -> dict:
         _walk_nested_dict(data, substitutions)
 
     return data
+
+
+def check_dict_is_contained_in_another(filter_data: dict, data: dict) -> bool:
+    """
+    Check if a dict is contained in another one.
+
+    * Works with nested dicts by using _dot notation_ in the filter_data keys
+      so a filter with
+      `{"base_key.sub_key": "value"}`
+      will look for dicts containing
+      `{"base_key": {"sub_key": "value"}}`
+    """
+    for key, value in filter_data.items():
+        if key in data:
+            if data[key] != value:
+                return False
+            continue
+
+        if "." in key:
+            base_key, sub_key = key.split(".", maxsplit=1)
+            if base_key not in data:
+                return False
+
+            base_value = data[base_key]
+            if not isinstance(base_value, dict):
+                return False
+
+            if not check_dict_is_contained_in_another({sub_key: value}, base_value):
+                return False
+
+            continue
+
+        return False
+
+    return True

--- a/custom_components/eventsensor/sensor.py
+++ b/custom_components/eventsensor/sensor.py
@@ -21,6 +21,7 @@ from .common import (
     CONF_STATE_MAP,
     DOMAIN,
     DOMAIN_DATA,
+    check_dict_is_contained_in_another,
     extract_state_from_event,
     make_unique_id,
     parse_numbers,
@@ -153,8 +154,7 @@ class EventSensor(RestoreEntity):
         @callback
         def async_update_sensor(event: Event):
             """Update state when event is received."""
-            # TODO make better filter looking at sub-nested data
-            if self._event_data.items() <= event.data.items():
+            if check_dict_is_contained_in_another(self._event_data, event.data):
                 # Extract new state
                 new_state = extract_state_from_event(self._state_key, event.data)
 


### PR DESCRIPTION
supporting nested pairs of key:value by using dot.notation on the subkeys, and closing #13 

cc @Fabenissimo 

### Listening to events with nested data

 For both the `event_data` and the desired sensor `state`, the _dot.notation_ can be used to point to nested keys in the event data, so, for an event like:

 ```json
{
    "event_type": "netatmo_event",
    "data": {
        "type": "movement",
        "data": {
            "user_id": "x",
            "snapshot_id": "x",
            "snapshot_key": "x",
            "snapshot_url": "x",
            "event_type": "movement",
            "camera_id": "ma:ca:dr:es:sx:xx",
            "device_id": "ma:ca:dr:es:sx:xx",
            "home_id": "x",
            "home_name": "x",
            "event_id": "x",
            "message": "Bewegung von Camera Treppenhaus erkannt",
            "push_type": "NACamera-movement"
        }
    },
    "origin": "LOCAL",
    "time_fired": "2020-07-25T09:12:49.580668+00:00",
    "context": {
        "id": "x",
        "parent_id": null,
        "user_id": null
    }
}
```

 To filter with the `type` and the `device_id` value, and create the state with the `push_type` data, the configuration in UI would be as follows:

* Event field: `data.push_type`
* Event filter: `type: movement, data.device_id: ma:ca:dr:es:sx:xx`