### PR TITLE
Add more templates for Aqara devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v2.2.0](https://github.com/azogue/eventsensor/tree/v2.2.0) (2020-08-02)
+
+[Full Changelog](https://github.com/azogue/eventsensor/compare/v2.1.0...v2.2.0)
+
+**Implemented enhancements:**
+
+- Better filter of event_data, using `dot.notation` for nested keys.
+- Add default mapping templates for Aqara Smart Button and Aqara Cube.
+
 ## [v2.1.0](https://github.com/azogue/eventsensor/tree/v2.1.0) (2020-04-29)
 
 [Full Changelog](https://github.com/azogue/eventsensor/compare/v2.0.0...v2.1.0)

--- a/custom_components/eventsensor/common.py
+++ b/custom_components/eventsensor/common.py
@@ -11,6 +11,29 @@ DOMAIN_DATA = f"{DOMAIN}_data"
 
 CONF_STATE_MAP = "state_map"
 
+PRESET_AQARA_CUBE = "Aqara Cube"
+PRESET_AQARA_CUBE_MAPPING = {
+    0: "Wake",
+    1: "Shake",
+    2: "Drop",
+    3: "Flip90",
+    4: "Flip180",
+    5: "Push",
+    6: "DoubleTap",
+    7: "RotCW",
+    8: "RotCCW",
+}
+PRESET_AQARA_SMART_BUTTON = "Aqara Smart Button"
+PRESET_AQARA_SMART_BUTTON_MAPPING = {
+    1000: "click",
+    1001: "hold",
+    1002: "click_up",
+    1003: "hold_up",
+    1004: "2_click",
+    1005: "3_click",
+    1006: "4_click",
+    1010: "5_click",
+}
 PRESET_FOH = "FoH Switch"
 PRESET_FOH_MAPPING = {
     16: "left_upper_press",

--- a/custom_components/eventsensor/config_flow.py
+++ b/custom_components/eventsensor/config_flow.py
@@ -11,6 +11,10 @@ from homeassistant.helpers.event import EVENT_STATE_CHANGED
 from .common import (
     CONF_STATE_MAP,
     DOMAIN,
+    PRESET_AQARA_CUBE,
+    PRESET_AQARA_CUBE_MAPPING,
+    PRESET_AQARA_SMART_BUTTON,
+    PRESET_AQARA_SMART_BUTTON_MAPPING,
     PRESET_FOH,
     PRESET_FOH_MAPPING,
     PRESET_HUE_DIMMER,
@@ -51,7 +55,14 @@ STEP_2_PRECONFIGURED = vol.Schema(
         ),
         vol.Optional(CONF_IDENTIFIER, default=""): str,
         vol.Required(CONF_PRESET_CONFIG, default=PRESET_HUE_DIMMER): vol.In(
-            [PRESET_HUE_DIMMER, PRESET_HUE_TAP, PRESET_FOH, _PRESET_GENERIC]
+            [
+                PRESET_HUE_DIMMER,
+                PRESET_HUE_TAP,
+                PRESET_FOH,
+                PRESET_AQARA_SMART_BUTTON,
+                PRESET_AQARA_CUBE,
+                _PRESET_GENERIC,
+            ]
         ),
     },
 )
@@ -142,6 +153,11 @@ class EventSensorFlowHandler(config_entries.ConfigFlow):
                 preset_map = PRESET_HUE_TAP_MAPPING
             elif preset_config == PRESET_FOH:
                 preset_map = PRESET_FOH_MAPPING
+            elif preset_config == PRESET_AQARA_SMART_BUTTON:
+                preset_map = PRESET_AQARA_SMART_BUTTON_MAPPING
+            elif preset_config == PRESET_AQARA_CUBE:
+                preset_map = PRESET_AQARA_CUBE_MAPPING
+                self._data_steps_config[CONF_STATE] = "gesture"
             self._data_steps_config[CONF_STATE_MAP] = preset_map
 
             return await self.async_step_state_mapping()

--- a/custom_components/eventsensor/translations/en.json
+++ b/custom_components/eventsensor/translations/en.json
@@ -13,7 +13,7 @@
                     "state_map": "Desired mapping for the sensor states"
                 },
                 "description": "Define a custom event listener by setting:\n\n* Event name\n* Event field `key` or `key.sub_key` to use as the sensor state\n* Optional `key: value` pairs inside the event data to filter specific events\n* Optional custom mapping for sensor states\n\nTo define a custom mapping, introduce it as pairs between commas, like:\n**`code: state1, code2: state2, code3: state3`**\nDo the same for the event data filter, **using curly braces for nested dicts if necessary**",
-                "title": "EventSensor - generic definition"
+                "title": "EventSensor - Generic definition"
             },
             "preset": {
                 "data": {
@@ -22,14 +22,14 @@
                     "type_identifier": "Select the identifier field used to filter events for a specific remote"
                 },
                 "description": "* Add a unique identifier to filter events related to a specific remote.\n* Select a preconfigured mapping for custom states, or define a new one",
-                "title": "EventSensor - listener for FoH remote"
+                "title": "EventSensor - Listener for FoH remote"
             },
             "state_mapping": {
                 "data": {
                     "state_map": "Desired mapping for the sensor states as `raw_data: pretty_state,` pairs."
                 },
                 "description": "* Review or modify the state mapping for this sensor, or leave it empty for no special state mapping.\n\nTo define a custom mapping, introduce it as pairs between commas, like:\n**`code: state1, code2: state2, code3: state3`**",
-                "title": "EventSensor - custom state mapping"
+                "title": "EventSensor - Custom state mapping"
             },
             "user": {
                 "data": {
@@ -37,7 +37,7 @@
                     "name": "Name for the new sensor tracking events"
                 },
                 "description": "Create a **sensor entity** to show state and attributes for the last fired event of some kind.\n\n* Set a name for the new sensor\n* Select a specific Integration source for the events to listen for, or select 'Any other' to define a generic event listener.",
-                "title": "EventSensor - new"
+                "title": "EventSensor - New"
             }
         }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eventsensor"
-version = "2.1.0"
+version = "2.2.0"
 description = "HomeAssistant custom sensor to track specific events"
 authors = ["Eugenio Panadero <eugenio.panadero@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Changes

* Add template for Aqara Smart Button events (tested with deCONZ integration, they could be different on ZHA.
* Add template for Aqara Cube events to extract the **gesture**.
* Bump minor version to 2.2.0

Both mappings are tested with deCONZ integration, so they could be different on ZHA :(
These templates can be used as they are, or be modified (custom state names?) in the last stage of the sensor configuration.